### PR TITLE
Skip file when exception occurs while gzip processing

### DIFF
--- a/contrib/Installer/boinc/boinc/clsBoincProjectDownload.vb
+++ b/contrib/Installer/boinc/boinc/clsBoincProjectDownload.vb
@@ -144,7 +144,6 @@ Public Class clsBoincProjectDownload
                     Dim iStatus As Integer = AnalyzeProjectHeader2(sTeamGzipURL, sEtag, sTeamEtagFilePath, sProject)
                     Dim sProjectMasterFileName As String = GetGridFolder() + "NeuralNetwork\" + sProject + ".master.dat"
                     'store etag by project also
-
                     If iStatus <> 1 Or Not File.Exists(sProjectMasterFileName) Then
                         Try
                             'Find out what our team ID is
@@ -154,7 +153,8 @@ Public Class clsBoincProjectDownload
                             'un-gzip the file
                             ExtractGZipInnerArchive(sTeamEtagFilePath, GetGridFolder() + "NeuralNetwork\")
                         Catch ex As Exception
-                            Log("Error while downloading master team gz file: " + ex.Message + ", Retrying.")
+                            Log("Error while processing master team gz file for " + sProject + " : " + ex.Message + ", Skipping project.")
+                            Continue For
                         End Try
                     End If
 
@@ -174,7 +174,8 @@ Public Class clsBoincProjectDownload
                             End If
                         Catch ex As Exception
                             Dim sMsg As String = ex.Message
-                            Log("Error while downloading master project rac gz file : " + ex.Message + ", Retrying.")
+                            Log("Error while processing master project rac gz file for " + sProject + " : " + ex.Message + ", Skipping project.")
+                            Continue For
                         End Try
                     End If
                     'Scan for the Gridcoin team inside this project:


### PR DESCRIPTION
* change logging message to be approiate
1) we do not retry with this failure.
2) if we do fail here we should not continue to process a corrupt gzip
2a) this should solve the bade gzip from seti
2b) this should solve the magic number issue that occurs via lhc

We essentially instead of screwing up the nn we just skip the project. then we continue onto next ones and if we still meet above the requirement count we r good to go.this acts like we failed to download the project file period!