### PR TITLE
If mlQueue bug workaround

### DIFF
--- a/contrib/Installer/boinc/boinc/My Project/AssemblyInfo.vb
+++ b/contrib/Installer/boinc/boinc/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.20.8.82")>
-<Assembly: AssemblyFileVersion("1.20.8.82")>
+<Assembly: AssemblyVersion("1.20.8.83")>
+<Assembly: AssemblyFileVersion("1.20.8.83")>

--- a/contrib/Installer/boinc/boinc/Utilization.vb
+++ b/contrib/Installer/boinc/boinc/Utilization.vb
@@ -14,7 +14,7 @@ Public Class Utilization
     Private mlSpeakMagnitude As Double
     Public ReadOnly Property Version As Double
         Get
-            Return 426
+            Return 427
         End Get
     End Property
 

--- a/contrib/Installer/boinc/boinc/frmLiveTicker.vb
+++ b/contrib/Installer/boinc/boinc/frmLiveTicker.vb
@@ -79,8 +79,6 @@ Public Class frmLiveTicker
     End Sub
     Public Function GetCryptoPrice(sSymbol As String)
         Try
-
-            'Sample Ticker Format :  {"ticker":{"high":0.00003796,"low":0.0000365,"avg":0.00003723,"lastbuy":0.0000371,"lastsell":0.00003795,"buy":0.00003794,"sell":0.00003795,"lastprice":0.00003795,"updated":1420369200}}
             Dim sSymbol1 As String
             sSymbol1 = NiceTicker(sSymbol)
             Dim ccxPage As String = ""
@@ -92,7 +90,8 @@ Public Class frmLiveTicker
             Dim sURL As String = "https://c-cex.com/t/" + ccxPage
             Dim w As New MyWebClient
             Dim sJSON As String = w.DownloadString(sURL)
-            Dim sLast As String = ExtractValue(sJSON, "lastprice", ",")
+            Dim sLast As String = ExtractValue(sJSON, "lastprice")
+            sLast = Replace(sLast, ",", ".")
             Dim dprice As Double
             dprice = CDbl(sLast)
             Dim qBitcoin As Quote

--- a/contrib/Installer/boinc/boinc/modLiveTicker.vb
+++ b/contrib/Installer/boinc/boinc/modLiveTicker.vb
@@ -53,7 +53,6 @@
         'Remove " and :
         sOut = Replace(sOut, Chr(34), "")
         sOut = Replace(sOut, Chr(58), "")
-        Log("Debug EV: sOut " + sOut + " iPos1 " + iPos1.ToString + " iPos2 " + iPos2.ToString)
         Return sOut
     End Function
     Public Sub MegaQuote()

--- a/contrib/Installer/boinc/boinc/modLiveTicker.vb
+++ b/contrib/Installer/boinc/boinc/modLiveTicker.vb
@@ -38,16 +38,22 @@
         End If
         Return q
     End Function
-    Public Function ExtractValue(sData As String, sStartKey As String, sEndKey As String)
-        Dim iPos1 As Integer = InStr(1, sData, sStartKey)
-        iPos1 = iPos1 + Len(sStartKey)
-        Dim iPos2 As Integer = InStr(iPos1, sData, sEndKey)
-        iPos2 = iPos2
+    Public Function ExtractValue(sData As String, sKey As String)
+        Dim iPos1 As Integer = InStr(1, sData, sKey)
+        iPos1 = iPos1 + Len(sKey)
+        Dim iPos2 As Integer = InStr(iPos1, sData, ",")
+        'If the key is located at end with no further delimiter of , then check for } to confirm this and use as position
+        'Incase the field for what we request ends up at the end. This broke due to the fact field locations changed
+        If iPos2 = 0 Then
+            iPos2 = InStr(iPos1, sData, "}")
+        End If
+        'If still zero then return empty
         If iPos2 = 0 Then Return ""
         Dim sOut As String = Mid(sData, iPos1, iPos2 - iPos1)
+        'Remove " and :
         sOut = Replace(sOut, Chr(34), "")
-        sOut = Replace(sOut, ":", "")
-        sOut = Replace(sOut, ",", "")
+        sOut = Replace(sOut, Chr(58), "")
+        Log("Debug EV: sOut " + sOut + " iPos1 " + iPos1.ToString + " iPos2 " + iPos2.ToString)
         Return sOut
     End Function
     Public Sub MegaQuote()

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -228,14 +228,19 @@ Module modPersistedDataSystem
             '            sOut += "00000000000000000000000000000001,32767;"
             sOut += "</MAGNITUDES><QUOTES>"
 
+            'If total nework magnitude is greater then 1% tolerance of 115000 then don't form
+            'a contract with out of bounds magnitudes.
+            If lTotal >= (115000 * 0.01) Then
+                Log("Total Network Magnitude exceeds limits in contract: " + lTotal.ToString)
+                Return "<ERROR>Superblock Total Network Magnitude " + Trim(lTotal) + " out of bounds</ERROR>"
+            End If
+
             surrogateRow.Database = "Prices"
             surrogateRow.Table = "Quotes"
             Dim lstQUOTEs As List(Of Row) = GetList(surrogateRow, "*")
 
             For Each quote As Row In lstQUOTEs
                 Dim sRow As String = quote.PrimaryKey + "," + Num(quote.Magnitude) + ";"
-                lTotal = lTotal + Val("0" + Trim(quote.Magnitude))
-                lRows = lRows + 1
                 sOut += sRow
             Next
 

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -230,7 +230,7 @@ Module modPersistedDataSystem
 
             'If total nework magnitude is greater then 1% tolerance of 115000 then don't form
             'a contract with out of bounds magnitudes.
-            If lTotal >= (115000 * 0.01) Then
+            If lTotal >= (115000 + (115000 * 0.01)) Then
                 Log("Total Network Magnitude exceeds limits in contract: " + lTotal.ToString)
                 Return "<ERROR>Superblock Total Network Magnitude " + Trim(lTotal) + " out of bounds</ERROR>"
             End If

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -230,12 +230,11 @@ Module modPersistedDataSystem
 
             surrogateRow.Database = "Prices"
             surrogateRow.Table = "Quotes"
-            lstCPIDs = GetList(surrogateRow, "*")
+            Dim lstQUOTEs As List(Of Row) = GetList(surrogateRow, "*")
 
-            For Each cpid As Row In lstCPIDs
-                Dim dNeuralMagnitude As Double = 0
-                Dim sRow As String = cpid.PrimaryKey + "," + Num(cpid.Magnitude) + ";"
-                lTotal = lTotal + Val("0" + Trim(cpid.Magnitude))
+            For Each quote As Row In lstQUOTEs
+                Dim sRow As String = quote.PrimaryKey + "," + Num(quote.Magnitude) + ";"
+                lTotal = lTotal + Val("0" + Trim(quote.Magnitude))
                 lRows = lRows + 1
                 sOut += sRow
             Next
@@ -291,7 +290,7 @@ Module modPersistedDataSystem
             Return sOut
 
         Catch ex As Exception
-            Log("GetMagnitudeContract" + ex.Message)
+            Log("GetMagnitudeContract " + ex.Message)
             Return ""
         End Try
 
@@ -919,8 +918,8 @@ Module modPersistedDataSystem
         lstCPIDs.Sort(Function(x, y) x.PrimaryKey.CompareTo(y.PrimaryKey))
         Dim sMemoryName = IIf(mbTestNet, "magnitudes_testnet", "magnitudes")
         'Get CryptoCurrency Quotes:
-        Dim dBTC As Double = GetCryptoPrice("BTC").Price * 100
-        Dim dGRC As Double = GetCryptoPrice("GRC").Price * 10000000000
+        Dim dBTC As Double = GetCryptoPrice("BTC").Price
+        Dim dGRC As Double = GetCryptoPrice("GRC").Price * 100000000
         '8-16-2015
         Dim q As New Row
         q.Database = "Prices"
@@ -930,7 +929,7 @@ Module modPersistedDataSystem
         q.Synced = q.Expiration
 
         q.Magnitude = Trim(Math.Round(dBTC, 2))
-        Log("Storing Bitcoin price quote")
+        Log("Storing Bitcoin Price Quote")
         Store(q)
         q = New Row
         q.Database = "Prices"
@@ -1767,9 +1766,7 @@ Retry:
             Catch ex As Exception
 
             End Try
-            Dim sLast As String = ExtractValue(sJSON, "lastprice", "updated")
-            sLast = Replace(sLast, ",", ".")
-
+            Dim sLast As String = ExtractValue(sJSON, "lastprice")
             Dim dprice As Double
             dprice = CDbl(sLast)
             Dim qBitcoin As Quote

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -890,14 +890,19 @@ Module modPersistedDataSystem
 
             'Thread.Join
             For x As Integer = 1 To 120
-                If mlQueue = 0 Then Exit For
+                'Log if the queue is a negative number
+                If mlQueue < 0 Then
+                    Log("Warning: mlQueue has a negative number of " + mlQueue.ToString)
+                End If
+                'If queue is zero or less then zero we will exit here. The bug behind this should be solved in future
+                If mlQueue <= 0 Then Exit For
                 GuiDoEvents()
                 Threading.Thread.Sleep(200)
                 mlPercentComplete -= 1
                 If mlPercentComplete < 10 Then mlPercentComplete = 10
             Next
             Dim lNoWitnesses As Long = CPIDCountWithNoWitnesses()
-            If mlQueue = 0 And lNoWitnesses = 0 Then Exit For Else Log(Trim(lNoWitnesses) + " CPIDs remaining with no witnesses.  Cleaning up problem.")
+            If lNoWitnesses = 0 Then Exit For Else Log(Trim(lNoWitnesses) + " CPIDs remaining with no witnesses.  Cleaning up problem.")
         Next z
 
         Try

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -889,19 +889,14 @@ Module modPersistedDataSystem
 
             'Thread.Join
             For x As Integer = 1 To 120
-                'Log if the queue is a negative number
-                If mlQueue < 0 Then
-                    Log("Warning: mlQueue has a negative number of " + mlQueue.ToString)
-                End If
-                'If queue is zero or less then zero we will exit here. The bug behind this should be solved in future
-                If mlQueue <= 0 Then Exit For
+                If mlQueue = 0 Then Exit For
                 GuiDoEvents()
                 Threading.Thread.Sleep(200)
                 mlPercentComplete -= 1
                 If mlPercentComplete < 10 Then mlPercentComplete = 10
             Next
             Dim lNoWitnesses As Long = CPIDCountWithNoWitnesses()
-            If lNoWitnesses = 0 Then Exit For Else Log(Trim(lNoWitnesses) + " CPIDs remaining with no witnesses.  Cleaning up problem.")
+            If mlQueue = 0 And lNoWitnesses = 0 Then Exit For Else Log(Trim(lNoWitnesses) + " CPIDs remaining with no witnesses.  Cleaning up problem.")
         Next z
 
         Try


### PR DESCRIPTION
mlQueue can sometimes end up being a negative number this is problem some as before we checked if the queue was 0 and the cpids with no witnesses was 0 before exiting successfully when cleaning up this issue.

In a normal circumstance this can do the loop 5 times if there were still cpids remaining and mlqueue was not zero with success thou it was rare if this ever happened at all or perhaps this 5 loops was due to the bug in which now the scale and fixes affected it.

however if there was "0 cpids with no witnesses left" and mlqueue went negative it would do the full 5 loops often ending with a broken NN till a new sync was performed.

Behaviors I've witnessed over months regarding this before pin pointing the issue was:

1) Double the CPID data in NN with a bunch of empty data duplicate CPIDs (also occurred from the double sync)
2) Insanely high rac and magnitude for all users or in some cases some users while the rest of the users had valid data.

While item 2 occurred it of course could of made a contract due to that rounding bug I found and fixed a few commits back. however with that previous fix this would of results in a empty contract! so thats a blessing thou in a rare case it may actually occur so I added a Warning message about mlQueue for logging purposes.

Heres the data I collected from recent problem:

Successful sync:

`Mar 31 2018 21:06, Starting Phase II
Mar 31 2018 21:06, Complete Sync: Updating mags
Mar 31 2018 21:06, Updating Magnitudes Without consensus data
Mar 31 2018 21:06, 3297 CPIDs starting out with clean slate.
Mar 31 2018 21:13, 5 CPIDs remaining with no witnesses.  Cleaning up problem.
Mar 31 2018 21:13, UpdNetworkAvgs Start Time 
Mar 31 2018 21:13, UpdNetworkAvgs End Time
Mar 31 2018 21:13, Unable to get quote data probably due to SSL being blocked: Conversion from string "7440buysupport61028.85163185" to type 'Double' is not valid.
Mar 31 2018 21:13, Unable to get quote data probably due to SSL being blocked: Conversion from string "0.0000047buysupport0.84567783" to type 'Double' is not valid.
Mar 31 2018 21:13, Storing Bitcoin price quote
Mar 31 2018 21:13, Storing Gridcoin Price Quote
Mar 31 2018 21:13, Contracts in Project : 24, Whitelisted Count: 25`

Failure:

`Mar 31 2018 22:36, Starting Phase II
Mar 31 2018 22:36, Complete Sync: Updating mags
Mar 31 2018 22:36, Updating Magnitudes Without consensus data
Mar 31 2018 22:36, 3298 CPIDs starting out with clean slate.
Mar 31 2018 22:43, 60 CPIDs remaining with no witnesses.  Cleaning up problem.
Mar 31 2018 22:43, 0 CPIDs remaining with no witnesses.  Cleaning up problem.
Mar 31 2018 22:43, 0 CPIDs remaining with no witnesses.  Cleaning up problem.
Mar 31 2018 22:43, 0 CPIDs remaining with no witnesses.  Cleaning up problem.
Mar 31 2018 22:43, 0 CPIDs remaining with no witnesses.  Cleaning up problem.
Mar 31 2018 22:43, UpdNetworkAvgs Start Time 
Mar 31 2018 22:43, UpdNetworkAvgs End Time
Mar 31 2018 22:43, Unable to get quote data probably due to SSL being blocked: Conversion from string "7439buysupport71926.52424065" to type 'Double' is not valid.
Mar 31 2018 22:43, Unable to get quote data probably due to SSL being blocked: Conversion from string "0.00000476buysupport0.84560111" to type 'Double' is not valid.
Mar 31 2018 22:43, Storing Bitcoin price quote
Mar 31 2018 22:43, Storing Gridcoin Price Quote
Mar 31 2018 22:44, Contracts in Project : 7, Whitelisted Count: 25
Mar 31 2018 22:44, Not enough projects in contract.
`

as u see the 0 CPIDs remaining with no witnesses. Cleaning up problem. <-- translation mlQueue was negative and breaking it.

have a look. i've tried a few deletions and resync and will monitor this till tomorrow and see if the results stick. good thing is least we know how explain magnitude was giving bad data.