### PR TITLE
Nndllfixes

### DIFF
--- a/contrib/Installer/boinc/boinc/My Project/AssemblyInfo.vb
+++ b/contrib/Installer/boinc/boinc/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.20.8.82")>
-<Assembly: AssemblyFileVersion("1.20.8.82")>
+<Assembly: AssemblyVersion("1.20.8.83")>
+<Assembly: AssemblyFileVersion("1.20.8.83")>

--- a/contrib/Installer/boinc/boinc/Utilization.vb
+++ b/contrib/Installer/boinc/boinc/Utilization.vb
@@ -14,7 +14,7 @@ Public Class Utilization
     Private mlSpeakMagnitude As Double
     Public ReadOnly Property Version As Double
         Get
-            Return 426
+            Return 427
         End Get
     End Property
 

--- a/contrib/Installer/boinc/boinc/clsBoincProjectDownload.vb
+++ b/contrib/Installer/boinc/boinc/clsBoincProjectDownload.vb
@@ -154,6 +154,8 @@ Public Class clsBoincProjectDownload
                             ExtractGZipInnerArchive(sTeamEtagFilePath, GetGridFolder() + "NeuralNetwork\")
                         Catch ex As Exception
                             Log("Error while processing master team gz file for " + sProject + " : " + ex.Message + ", Skipping project.")
+                            Log("Deleting master team gz file for " + sProject)
+                            File.Delete(sTeamEtagFilePath)
                             Continue For
                         End Try
                     End If
@@ -175,6 +177,8 @@ Public Class clsBoincProjectDownload
                         Catch ex As Exception
                             Dim sMsg As String = ex.Message
                             Log("Error while processing master project rac gz file for " + sProject + " : " + ex.Message + ", Skipping project.")
+                            Log("Deleting master project gz file for " + sProject)
+                            File.Delete(sRacEtagFilePath)
                             Continue For
                         End Try
                     End If

--- a/contrib/Installer/boinc/boinc/clsBoincProjectDownload.vb
+++ b/contrib/Installer/boinc/boinc/clsBoincProjectDownload.vb
@@ -144,7 +144,6 @@ Public Class clsBoincProjectDownload
                     Dim iStatus As Integer = AnalyzeProjectHeader2(sTeamGzipURL, sEtag, sTeamEtagFilePath, sProject)
                     Dim sProjectMasterFileName As String = GetGridFolder() + "NeuralNetwork\" + sProject + ".master.dat"
                     'store etag by project also
-
                     If iStatus <> 1 Or Not File.Exists(sProjectMasterFileName) Then
                         Try
                             'Find out what our team ID is
@@ -154,7 +153,8 @@ Public Class clsBoincProjectDownload
                             'un-gzip the file
                             ExtractGZipInnerArchive(sTeamEtagFilePath, GetGridFolder() + "NeuralNetwork\")
                         Catch ex As Exception
-                            Log("Error while downloading master team gz file: " + ex.Message + ", Retrying.")
+                            Log("Error while processing master team gz file for " + sProject + " : " + ex.Message + ", Skipping project.")
+                            Continue For
                         End Try
                     End If
 
@@ -174,7 +174,8 @@ Public Class clsBoincProjectDownload
                             End If
                         Catch ex As Exception
                             Dim sMsg As String = ex.Message
-                            Log("Error while downloading master project rac gz file : " + ex.Message + ", Retrying.")
+                            Log("Error while processing master project rac gz file for " + sProject + " : " + ex.Message + ", Skipping project.")
+                            Continue For
                         End Try
                     End If
                     'Scan for the Gridcoin team inside this project:

--- a/contrib/Installer/boinc/boinc/frmLiveTicker.vb
+++ b/contrib/Installer/boinc/boinc/frmLiveTicker.vb
@@ -79,8 +79,6 @@ Public Class frmLiveTicker
     End Sub
     Public Function GetCryptoPrice(sSymbol As String)
         Try
-
-            'Sample Ticker Format :  {"ticker":{"high":0.00003796,"low":0.0000365,"avg":0.00003723,"lastbuy":0.0000371,"lastsell":0.00003795,"buy":0.00003794,"sell":0.00003795,"lastprice":0.00003795,"updated":1420369200}}
             Dim sSymbol1 As String
             sSymbol1 = NiceTicker(sSymbol)
             Dim ccxPage As String = ""
@@ -92,7 +90,8 @@ Public Class frmLiveTicker
             Dim sURL As String = "https://c-cex.com/t/" + ccxPage
             Dim w As New MyWebClient
             Dim sJSON As String = w.DownloadString(sURL)
-            Dim sLast As String = ExtractValue(sJSON, "lastprice", ",")
+            Dim sLast As String = ExtractValue(sJSON, "lastprice")
+            sLast = Replace(sLast, ",", ".")
             Dim dprice As Double
             dprice = CDbl(sLast)
             Dim qBitcoin As Quote

--- a/contrib/Installer/boinc/boinc/modLiveTicker.vb
+++ b/contrib/Installer/boinc/boinc/modLiveTicker.vb
@@ -38,16 +38,17 @@
         End If
         Return q
     End Function
-    Public Function ExtractValue(sData As String, sStartKey As String, sEndKey As String)
-        Dim iPos1 As Integer = InStr(1, sData, sStartKey)
-        iPos1 = iPos1 + Len(sStartKey)
-        Dim iPos2 As Integer = InStr(iPos1, sData, sEndKey)
-        iPos2 = iPos2
+    Public Function ExtractValue(sData As String, sKey As String)
+        Dim iPos1 As Integer = InStr(1, sData, sKey)
+        iPos1 = iPos1 + Len(sKey)
+        Dim iPos2 As Integer = InStr(iPos1, sData, ",")
+        'Incase the location of sKey moves to end of the json -- This similar scenario broke the quotes
+        If iPos2 = 0 Then iPos2 = InStr(iPos1, sData, "}")
+        'If 0 then return nothing
         If iPos2 = 0 Then Return ""
         Dim sOut As String = Mid(sData, iPos1, iPos2 - iPos1)
         sOut = Replace(sOut, Chr(34), "")
-        sOut = Replace(sOut, ":", "")
-        sOut = Replace(sOut, ",", "")
+        sOut = Replace(sOut, Chr(58), "")
         Return sOut
     End Function
     Public Sub MegaQuote()

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -849,7 +849,8 @@ Module modPersistedDataSystem
         Log("Updating Magnitudes " + IIf(bConsensus, "With consensus data", "Without consensus data"))
         Dim lStartingWitnesses As Long = CPIDCountWithNoWitnesses()
         Log(Trim(lStartingWitnesses) + " CPIDs starting out with clean slate.")
-
+        Dim MaxWitnessLoopCount As Integer = 5
+        Dim CurrentWitnessLoopCount As Integer = 0
         For z As Integer = 1 To 5
             Dim iRow As Long = 0
 
@@ -914,7 +915,9 @@ ThreadSleep:
                 'If Queue is greater then 0 then handle this situation properly! This means there is still Threads for CPIDs in queue or running.
             ElseIf mlQueueCopy > 0 Then
                 If lNoWitnesses = 0 Then
-                    Log("No CPIDs remaining with no witness, but mlQueue persists with " + Trim(mlQueueCopy) + "; Sleeping to try rectify problem.")
+                    If CurrentWitnessLoopCount >= MaxWitnessLoopCount Then Exit For
+                    CurrentWitnessLoopCount += 1
+                    Log("No CPIDs remaining with no witness, but mlQueue persists with " + Trim(mlQueueCopy) + "; Sleeping to try rectify problem. Attempt " + Trim(CurrentWitnessLoopCount) + "/" + Trim(MaxWitnessLoopCount))
                     GoTo ThreadSleep
                 Else
                     Log(Trim(lNoWitnesses) + " CPIDs remaining with no witness and mlQueue persists with " + Trim(mlQueueCopy) + "; Sleeping to allow completion of threads")

--- a/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
+++ b/contrib/Installer/boinc/boinc/modPersistedDataSystem.vb
@@ -226,21 +226,15 @@ Module modPersistedDataSystem
             'binary superblock will diff. When the 70 average mag requirement has been lifted from the
             'C++ code this placeholder can be removed.
             '            sOut += "00000000000000000000000000000001,32767;"
-            sOut += "</MAGNITUDES><QUOTES>"
+            sOut += "</MAGNITUDES>"
 
-            surrogateRow.Database = "Prices"
-            surrogateRow.Table = "Quotes"
-            lstCPIDs = GetList(surrogateRow, "*")
+            'If total network magnitude exceeds 1% tolerance of 115000 (116150) then do not form a contract
+            If lTotal > (115000 * 1.01) Then
+                Log("Total Network Magnitude out of bounds: " + Trim(lTotal))
+                Return "<ERROR>Contract Total Network Magnitude " + Trim(lTotal) + " out of bounds</ERROR>"
+            End If
 
-            For Each cpid As Row In lstCPIDs
-                Dim dNeuralMagnitude As Double = 0
-                Dim sRow As String = cpid.PrimaryKey + "," + Num(cpid.Magnitude) + ";"
-                lTotal = lTotal + Val("0" + Trim(cpid.Magnitude))
-                lRows = lRows + 1
-                sOut += sRow
-            Next
-
-            sOut += "</QUOTES><AVERAGES>"
+            sOut += "<AVERAGES>"
             Dim avg As Double
             avg = lTotal / (lRows + 0.01)
 
@@ -291,7 +285,7 @@ Module modPersistedDataSystem
             Return sOut
 
         Catch ex As Exception
-            Log("GetMagnitudeContract" + ex.Message)
+            Log("GetMagnitudeContract: " + ex.Message)
             Return ""
         End Try
 
@@ -865,6 +859,8 @@ Module modPersistedDataSystem
                 surrogateRow.Table = "CPIDS"
                 lstCPIDs = GetList(surrogateRow, "*")
                 lstCPIDs.Sort(Function(x, y) x.PrimaryKey.CompareTo(y.PrimaryKey))
+                'If Queue is <> 0 then Warn about undefined outcome. This should not occur anymore but would be a nice log catch if it does!
+                If mlQueue <> 0 Then Log("Warning: Reiterating through CPIDS due to some CPIDS having no witness; However mlQueue is not as expected " + Trim(mlQueue))
                 mlQueue = 0
                 For Each cpid As Row In lstCPIDs
                     Try
@@ -889,6 +885,7 @@ Module modPersistedDataSystem
             End Try
 
             'Thread.Join
+ThreadSleep:
             For x As Integer = 1 To 120
                 If mlQueue = 0 Then Exit For
                 GuiDoEvents()
@@ -897,7 +894,33 @@ Module modPersistedDataSystem
                 If mlPercentComplete < 10 Then mlPercentComplete = 10
             Next
             Dim lNoWitnesses As Long = CPIDCountWithNoWitnesses()
-            If mlQueue = 0 And lNoWitnesses = 0 Then Exit For Else Log(Trim(lNoWitnesses) + " CPIDs remaining with no witnesses.  Cleaning up problem.")
+            'If mlQueue = 0 And lNoWitnesses = 0 Then Exit For Else Log(Trim(lNoWitnesses) + " CPIDs remaining with no witnesses.  Cleaning up problem.")
+            'If Queue is 0 and the count in question is 0 we exit the loop as complete
+            'Decided to use small lock scope here and copy the number instead of making this area more complicated then need be.
+            Dim mlQueueCopy As Long = mlQueue
+            If mlQueueCopy = 0 And lNoWitnesses = 0 Then
+                Log("No CPIDs remain with no witness; Success")
+                Exit For
+                'If Queue is less then 0 which is a critical problem to RAC/MAG bug we handle the situation better
+                'However the locks should of taken care of this and I have not seen any of this case since
+            ElseIf mlQueueCopy < 0 Then
+                If lNoWitnesses = 0 Then
+                    Log("Warning: mlQueue is negative but no CPIDs with no witness remain! Undefined behaviour with contract possible; Continuing contract creation")
+                    Exit For
+                Else
+                    Log("Warning: mlQueue is negative but some CPIDs have no witness! Undefined behaviour with contract possible; Sleeping to try to rectify problem.")
+                    GoTo ThreadSleep
+                End If
+                'If Queue is greater then 0 then handle this situation properly! This means there is still Threads for CPIDs in queue or running.
+            ElseIf mlQueueCopy > 0 Then
+                If lNoWitnesses = 0 Then
+                    Log("No CPIDs remaining with no witness, but mlQueue persists with " + Trim(mlQueueCopy) + "; Sleeping to try rectify problem.")
+                    GoTo ThreadSleep
+                Else
+                    Log(Trim(lNoWitnesses) + " CPIDs remaining with no witness and mlQueue persists with " + Trim(mlQueueCopy) + "; Sleeping to allow completion of threads")
+                    GoTo ThreadSleep
+                End If
+            End If
         Next z
 
         Try
@@ -913,29 +936,6 @@ Module modPersistedDataSystem
         lstWhitelist = GetWPC(WhitelistedProjects, ProjCount)
         lstCPIDs.Sort(Function(x, y) x.PrimaryKey.CompareTo(y.PrimaryKey))
         Dim sMemoryName = IIf(mbTestNet, "magnitudes_testnet", "magnitudes")
-        'Get CryptoCurrency Quotes:
-        Dim dBTC As Double = GetCryptoPrice("BTC").Price * 100
-        Dim dGRC As Double = GetCryptoPrice("GRC").Price * 10000000000
-        '8-16-2015
-        Dim q As New Row
-        q.Database = "Prices"
-        q.Table = "Quotes"
-        q.PrimaryKey = "BTC"
-        q.Expiration = DateAdd(DateInterval.Day, 1, Now)
-        q.Synced = q.Expiration
-
-        q.Magnitude = Trim(Math.Round(dBTC, 2))
-        Log("Storing Bitcoin price quote")
-        Store(q)
-        q = New Row
-        q.Database = "Prices"
-        q.Table = "Quotes"
-        q.Expiration = DateAdd(DateInterval.Day, 1, Now)
-        q.PrimaryKey = "GRC"
-        q.Magnitude = Trim(Math.Round(dGRC, 2))
-        q.Synced = q.Expiration
-        Log("Storing Gridcoin Price Quote")
-        Store(q)
 
         'Update all researchers magnitudes (Final Calculation Phase):
         Dim surrogatePrj As New Row
@@ -1118,7 +1118,10 @@ TryAgain:
             Threading.ThreadPool.QueueUserWorkItem(AddressOf ThreadGetRac, oNeuralType)
 
 ThreadStarted:
-            mlQueue += 1
+            Dim mlLock As New Object
+            SyncLock mlLock
+                mlQueue += 1
+            End SyncLock
             If lCatastrophicFailures > 0 Then
                 Log("Successfully recovered from catastrophic failures.")
             End If
@@ -1160,7 +1163,10 @@ ThreadStarted:
                 Log("Attempt # " + Trim(x) + ": Error in ThreadGetRAC : " + ex.Message + ", Trying again.")
             End Try
         Next x
-        mlQueue -= 1
+        Dim mlLock As New Object
+        SyncLock mlLock
+            mlQueue -= 1
+        End SyncLock
     End Sub
     Public Function GetSupermajorityVoteStatus(sCPID As String, lMinimumWitnessesRequired As Long) As Boolean
         If mdictNeuralNetworkQuorumData Is Nothing Then Return False
@@ -1762,9 +1768,7 @@ Retry:
             Catch ex As Exception
 
             End Try
-            Dim sLast As String = ExtractValue(sJSON, "lastprice", "updated")
-            sLast = Replace(sLast, ",", ".")
-
+            Dim sLast As String = ExtractValue(sJSON, "lastprice")
             Dim dprice As Double
             dprice = CDbl(sLast)
             Dim qBitcoin As Quote


### PR DESCRIPTION
* Fix BTC/GRC Prices in sb.
* Add rule to prevent making of contract beyond tolerance of 1% of total network magnitude
* Lock mlQueue for +1 and -1 (this keeps the count always correct! and no more negatives and races)
* Add logging and handle negative mlQueue if it happens to happen so we know it does happen
* Add logging and handle queue that has not yet reached 0 and sleep till it completes. This prevents the massive data races
* increment versions

Pros:
Locks do slow down the thread rac parts a bit but it is no slower then before since we not looping up to 5 times through the ThreadRAC sections  to wait for the data to match in queue. race eliminated.